### PR TITLE
A handful of small changes

### DIFF
--- a/patches/html2canvas+1.2.1.patch
+++ b/patches/html2canvas+1.2.1.patch
@@ -6,7 +6,7 @@ index dfa7f75..fce2e79 100644
              this.path(effect.path);
              this.ctx.clip();
          }
-+        this.ctx.globalCompositeOperation = 'darken'
++        this.ctx.globalCompositeOperation = 'multiply'
          this._activeEffects.push(effect);
      };
      CanvasRenderer.prototype.popEffect = function () {

--- a/src/components/ArrowLine.tsx
+++ b/src/components/ArrowLine.tsx
@@ -41,7 +41,7 @@ export default function ArrowLine({
           points={pointsString}
           stroke='white'
           fill='none'
-          style={{ mixBlendMode: 'darken' }}
+          style={{ mixBlendMode: 'multiply' }}
           strokeWidth={strokeWidth * 3}
         />
       )}

--- a/src/components/Controls.tsx
+++ b/src/components/Controls.tsx
@@ -1,4 +1,5 @@
-import React from 'react'
+import React, { useCallback } from 'react'
+import { useFilePath } from '../hooks/useFile'
 import { setShowStraightArrows } from '../reducer'
 import { useDispatch, useSelector } from '../store'
 import { redo, reset, undo, useCanUndoRedo } from '../undoable'
@@ -7,7 +8,6 @@ import Export from './Export'
 export default function Controls() {
   const dispatch = useDispatch()
   const showStraightArrows = useSelector((state) => state.showStraightArrows)
-  const { canUndo, canRedo } = useCanUndoRedo()
 
   return (
     <div className='annotation-controls'>
@@ -18,16 +18,56 @@ export default function Controls() {
         onChange={(e) => dispatch(setShowStraightArrows(e.target.checked))}
       />
       <label htmlFor='straight-arrows'>Use straight arrows</label>
-      <div>
-        <button disabled={!canUndo} onClick={() => dispatch(undo())}>
-          undo
-        </button>
-        <button disabled={!canRedo} onClick={() => dispatch(redo())}>
-          redo
-        </button>
-        <button onClick={() => dispatch(reset())}>clear</button>
-      </div>
+      <UndoManagement />
       <Export />
+      {import.meta.env.DEV && <PersistedStateDebugging />}
+    </div>
+  )
+}
+
+function UndoManagement() {
+  const dispatch = useDispatch()
+  const { canUndo, canRedo } = useCanUndoRedo()
+
+  return (
+    <div>
+      <button disabled={!canUndo} onClick={() => dispatch(undo())}>
+        undo
+      </button>
+      <button disabled={!canRedo} onClick={() => dispatch(redo())}>
+        redo
+      </button>
+      <button onClick={() => dispatch(reset())}>clear</button>
+    </div>
+  )
+}
+
+function PersistedStateDebugging() {
+  const filePath = useFilePath()
+  const paste = useCallback(() => {
+    const key = `persist:state:${filePath}`
+    navigator.clipboard
+      .readText()
+      .then((text) => localStorage.setItem(key, text))
+      .then(() => console.log('pasted'))
+  }, [])
+
+  const copy = useCallback(() => {
+    const key = `persist:state:${filePath}`
+    const localStorageValue = localStorage.getItem(key)
+    if (!localStorageValue) {
+      console.error(`Value missing in local storage`)
+      return
+    }
+    navigator.clipboard
+      .writeText(localStorageValue)
+      .then(() => console.log('copied'))
+  }, [])
+
+  return (
+    <div>
+      <button onClick={copy}>copy persisted state</button>
+      <button onClick={paste}>paste persisted state</button>
     </div>
   )
 }

--- a/src/components/Popover.tsx
+++ b/src/components/Popover.tsx
@@ -26,8 +26,8 @@ export function Popover({ origin, autofocus = false, children }: Props) {
       className='popover'
       style={
         {
-          '--top': `${origin.y}px`,
-          '--left': `${origin.x}px`,
+          '--top': `${Math.round(origin.y)}px`,
+          '--left': `${Math.round(origin.x)}px`,
           '--transform': 'translateX(-50%)',
         } as React.CSSProperties
       }

--- a/src/components/Popover.tsx
+++ b/src/components/Popover.tsx
@@ -6,9 +6,15 @@ import { Point } from '../types'
 type Props = PropsWithChildren<{
   origin: Point
   autofocus?: boolean
+  className?: string
 }>
 
-export function Popover({ origin, autofocus = false, children }: Props) {
+export function Popover({
+  origin,
+  autofocus = false,
+  children,
+  className,
+}: Props) {
   const dispatch = useDispatch()
   const ref = React.useRef<HTMLDivElement | null>(null)
   React.useEffect(() => {
@@ -23,7 +29,7 @@ export function Popover({ origin, autofocus = false, children }: Props) {
       onBlur={autofocus ? () => dispatch(clearSelection()) : undefined}
       onMouseDown={autofocus ? (event) => event.preventDefault() : undefined}
       tabIndex={autofocus ? 1 : undefined}
-      className='popover'
+      className={`popover ${className ?? ''}`}
       style={
         {
           '--top': `${Math.round(origin.y)}px`,

--- a/src/components/SelectionPopover.tsx
+++ b/src/components/SelectionPopover.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { shallowEqual } from 'react-redux'
 import { addMarker, removeArrow, removeMarker } from '../reducer'
 import { useDispatch, useSelector } from '../store'
+import { Arrow, Marker, Point, Rect } from '../types'
 import { Popover } from './Popover'
 
 export default function SelectionPopover() {
@@ -9,8 +10,6 @@ export default function SelectionPopover() {
     (state) => state.currentSelection,
     shallowEqual,
   )
-  const colors = useSelector((state) => state.colors, shallowEqual)
-  const dispatch = useDispatch()
 
   if (!currentSelection) {
     return null
@@ -18,51 +17,65 @@ export default function SelectionPopover() {
 
   switch (currentSelection.type) {
     case 'text': {
-      return (
-        <Popover
-          origin={{
-            x: currentSelection.rect.left + currentSelection.rect.width / 2,
-            y: currentSelection.rect.bottom,
-          }}
-        >
-          {colors.map((color) => (
-            <button
-              key={color}
-              className='color-button'
-              style={{ '--color': color } as React.CSSProperties}
-              onClick={() =>
-                dispatch(addMarker({ rect: currentSelection.rect, color }))
-              }
-            />
-          ))}
-        </Popover>
-      )
+      return <TextPopover rect={currentSelection.rect} />
     }
     case 'marker': {
-      return (
-        <Popover
-          autofocus
-          origin={{
-            x: currentSelection.marker.left + currentSelection.marker.width / 2,
-            y: currentSelection.marker.bottom,
-          }}
-        >
-          <button
-            onClick={() => dispatch(removeMarker(currentSelection.marker))}
-          >
-            remove
-          </button>
-        </Popover>
-      )
+      return <MarkerPopover marker={currentSelection.marker} />
     }
     case 'arrow': {
       return (
-        <Popover autofocus origin={currentSelection.point}>
-          <button onClick={() => dispatch(removeArrow(currentSelection.arrow))}>
-            remove
-          </button>
-        </Popover>
+        <ArrowPopover
+          arrow={currentSelection.arrow}
+          point={currentSelection.point}
+        />
       )
     }
   }
+}
+
+function TextPopover({ rect }: { rect: Rect }) {
+  const dispatch = useDispatch()
+  const colors = useSelector((state) => state.colors, shallowEqual)
+  return (
+    <Popover
+      origin={{
+        x: rect.left + rect.width / 2,
+        y: rect.bottom,
+      }}
+    >
+      {colors.map((color) => (
+        <button
+          key={color}
+          className='color-button'
+          style={{ '--color': color } as React.CSSProperties}
+          onClick={() => dispatch(addMarker({ rect, color }))}
+        />
+      ))}
+    </Popover>
+  )
+}
+
+function MarkerPopover({ marker }: { marker: Marker }) {
+  const dispatch = useDispatch()
+  return (
+    <Popover
+      autofocus
+      origin={{
+        x: marker.left + marker.width / 2,
+        y: marker.bottom,
+      }}
+      className='popover--marker'
+    >
+      <button onClick={() => dispatch(removeMarker(marker))}>remove</button>
+    </Popover>
+  )
+}
+
+function ArrowPopover({ arrow, point }: { arrow: Arrow; point: Point }) {
+  const dispatch = useDispatch()
+  return (
+    <Popover autofocus origin={point} className='popover--arrow'>
+      <button onClick={() => dispatch(removeArrow(arrow))}>remove</button>
+    </Popover>
+  )
 }

--- a/src/hooks/useFile.ts
+++ b/src/hooks/useFile.ts
@@ -1,0 +1,20 @@
+import { useMemo } from 'react'
+import { useParams } from 'react-router-dom'
+import * as github from '../github'
+
+export function useFilePath(): string | null {
+  const { hash } = useParams<{ hash?: string }>()
+  if (!hash) {
+    return null
+  }
+  return github.parseFileHash(hash)
+}
+
+export function useFile(): github.File | null {
+  const filePath = useFilePath()
+  if (!filePath) {
+    return null
+  }
+
+  return useMemo(() => github.parsePath(filePath), [filePath])
+}

--- a/src/index.scss
+++ b/src/index.scss
@@ -62,6 +62,13 @@ body {
     background: gray;
     clip-path: polygon(0% 100%, 100% 100%, 50% 0%);
   }
+
+  &--arrow,
+  &--marker {
+    display: flex;
+    flex-direction: column;
+    justify-content: stretch;
+  }
 }
 
 .color-button {

--- a/src/index.scss
+++ b/src/index.scss
@@ -33,7 +33,7 @@ body {
     left: 0;
     width: 100%;
     height: 100%;
-    mix-blend-mode: darken;
+    mix-blend-mode: multiply;
   }
 }
 

--- a/src/pages/AnnotationPage.tsx
+++ b/src/pages/AnnotationPage.tsx
@@ -1,32 +1,15 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Provider } from 'react-redux'
-import { useParams } from 'react-router-dom'
 import { PersistGate } from 'redux-persist/integration/react'
 import Code from '../components/Code'
 import Controls from '../components/Controls'
 import SelectionPopover from '../components/SelectionPopover'
 import Svg from '../components/Svg'
 import * as github from '../github'
+import { useFile, useFilePath } from '../hooks/useFile'
 import useKeyboardHandler from '../hooks/useKeyboardHandler'
 import { setCode } from '../reducer'
 import createStore, { useDispatch, useSelector } from '../store'
-
-function useFilePath(): string | null {
-  const { hash } = useParams<{ hash?: string }>()
-  if (!hash) {
-    return null
-  }
-  return github.parseFileHash(hash)
-}
-
-function useFile(): github.File | null {
-  const filePath = useFilePath()
-  if (!filePath) {
-    return null
-  }
-
-  return useMemo(() => github.parsePath(filePath), [filePath])
-}
 
 export default function AnnotationPageWrapper() {
   const filePath = useFilePath()

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -2,30 +2,6 @@ import { AnyAction, createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { v4 as uuid } from 'uuid'
 import { Arrow, Marker, Point, Rect } from './types'
 
-const code = `function configFromInput(config) {
-  var input = config._i;
-  if (isUndefined(input)) {
-      config._d = new Date(hooks.now());
-  } else if (isDate(input)) {
-      config._d = new Date(input.valueOf());
-  } else if (typeof input === 'string') {
-      configFromString(config);
-  } else if (isArray(input)) {
-      config._a = map(input.slice(0), function (obj) {
-          return parseInt(obj, 10);
-      });
-      configFromArray(config);
-  } else if (isObject(input)) {
-      configFromObject(config);
-  } else if (isNumber(input)) {
-      // from milliseconds
-      config._d = new Date(input);
-  } else {
-      hooks.createFromInputFallback(config);
-  }
-}
-`
-
 export type State = {
   code: string | null
   currentSelection: Selection | null

--- a/src/util.ts
+++ b/src/util.ts
@@ -52,13 +52,3 @@ export function pointFromEvent(
     y: event.clientY - containerRect.top,
   }
 }
-
-export function toggleSetMember<T>(set: Set<T>, member: T): Set<T> {
-  const newSet = new Set(set)
-  if (set.has(member)) {
-    newSet.delete(member)
-  } else {
-    newSet.add(member)
-  }
-  return newSet
-}


### PR DESCRIPTION
These are some things I did while working on #3 (and a bigger refactor).
I wanted to separate these changes so that the upcoming PRs won't be too big.

Here are the changes:

- Round popover coordinates
- Remove unused variables
- Use `mix-blend-mode: multiply` instead of `darken`
- Add localStorage debugging buttons
- Make the marker/arrow popovers a little nicer

There's a bit more detail in the individual commit messages, but I'd like to flag an important one: the move from `darken` to `multiply` is a good one in terms of readability, but we'll have to figure something out for the dark color theme
