### PR TITLE
Add more colors and improve color selection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@reduxjs/toolkit": "^1.6.0",
         "html2canvas": "^1.2.1",
         "lz-string": "^1.4.4",
+        "material-colors-ts": "^1.0.4",
         "patch-package": "^6.4.7",
         "react": "^17.0.0",
         "react-dom": "^17.0.0",
@@ -1165,6 +1166,11 @@
       "bin": {
         "lz-string": "bin/bin.js"
       }
+    },
+    "node_modules/material-colors-ts": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/material-colors-ts/-/material-colors-ts-1.0.4.tgz",
+      "integrity": "sha512-gInR5UI3NGf1sxMOye73w2D7jfFTk60zz260ZxPUiHlRo+XxSs4/Vz5xZx28VaKCPitUE+ze4gC68vue/4BSvA=="
     },
     "node_modules/micromatch": {
       "version": "4.0.4",
@@ -2653,6 +2659,11 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
       "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY="
+    },
+    "material-colors-ts": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/material-colors-ts/-/material-colors-ts-1.0.4.tgz",
+      "integrity": "sha512-gInR5UI3NGf1sxMOye73w2D7jfFTk60zz260ZxPUiHlRo+XxSs4/Vz5xZx28VaKCPitUE+ze4gC68vue/4BSvA=="
     },
     "micromatch": {
       "version": "4.0.4",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@reduxjs/toolkit": "^1.6.0",
     "html2canvas": "^1.2.1",
     "lz-string": "^1.4.4",
+    "material-colors-ts": "^1.0.4",
     "patch-package": "^6.4.7",
     "react": "^17.0.0",
     "react-dom": "^17.0.0",

--- a/src/colors.ts
+++ b/src/colors.ts
@@ -22,14 +22,21 @@ export const colors = [
 
 export type Color = ArrayElement<typeof colors>
 
-function cssColorFromColor(
+export type Brightness = 'light' | 'medium' | 'dark'
+
+export function cssColorFromColor(
   color: Color | 'lightblue' | 'lightgreen' | 'gold',
+  brightness: Brightness,
 ): string {
   switch (color) {
-    case 'lightblue':
-    case 'lightgreen':
+    case 'lightblue': {
+      return cssColorFromColor('lightBlue', brightness)
+    }
+    case 'lightgreen': {
+      return cssColorFromColor('lightGreen', brightness)
+    }
     case 'gold': {
-      return color
+      return cssColorFromColor('orange', brightness)
     }
     case 'pink':
     case 'purple':
@@ -47,12 +54,22 @@ function cssColorFromColor(
     case 'orange':
     case 'deepOrange':
     case 'red': {
-      return materialColors[color][200]
+      const variant = variantForBrightness(brightness)
+      return materialColors[color][variant]
     }
   }
 }
 
-// in the future this would allow more customization such as light/dark themes
-export function useCssColor(color: Color) {
-  return cssColorFromColor(color)
+function variantForBrightness(brightness: Brightness): 100 | 200 | 300 {
+  switch (brightness) {
+    case 'light': {
+      return 100
+    }
+    case 'medium': {
+      return 200
+    }
+    case 'dark': {
+      return 300
+    }
+  }
 }

--- a/src/colors.ts
+++ b/src/colors.ts
@@ -1,0 +1,58 @@
+import materialColors from 'material-colors-ts'
+import { ArrayElement } from './util'
+
+export const colors = [
+  'pink',
+  'purple',
+  'deepPurple',
+  'indigo',
+  'blue',
+  'lightBlue',
+  'cyan',
+  'teal',
+  'green',
+  'lightGreen',
+  'lime',
+  'yellow',
+  'amber',
+  'orange',
+  'deepOrange',
+  'red',
+] as const
+
+export type Color = ArrayElement<typeof colors>
+
+function cssColorFromColor(
+  color: Color | 'lightblue' | 'lightgreen' | 'gold',
+): string {
+  switch (color) {
+    case 'lightblue':
+    case 'lightgreen':
+    case 'gold': {
+      return color
+    }
+    case 'pink':
+    case 'purple':
+    case 'deepPurple':
+    case 'indigo':
+    case 'blue':
+    case 'lightBlue':
+    case 'cyan':
+    case 'teal':
+    case 'green':
+    case 'lightGreen':
+    case 'lime':
+    case 'yellow':
+    case 'amber':
+    case 'orange':
+    case 'deepOrange':
+    case 'red': {
+      return materialColors[color][200]
+    }
+  }
+}
+
+// in the future this would allow more customization such as light/dark themes
+export function useCssColor(color: Color) {
+  return cssColorFromColor(color)
+}

--- a/src/components/ArrowLine.tsx
+++ b/src/components/ArrowLine.tsx
@@ -1,6 +1,6 @@
 import React, { MouseEvent } from 'react'
-import { useCssColor } from '../colors'
 import { arrowAngleForPoints, pointArrayForArrow } from '../geometry'
+import useCssColor from '../hooks/useCssColor'
 import { Arrow, UnfinishedArrow } from '../types'
 
 type Props = {

--- a/src/components/ArrowLine.tsx
+++ b/src/components/ArrowLine.tsx
@@ -23,7 +23,7 @@ export default function ArrowLine({
   const endPoint = points[points.length - 1]
   const arrowAngle = arrowAngleForPoints(points)
   const pointsString = points.map(({ x, y }) => `${x},${y}`).join(' ')
-  const color = arrow.fromMarker.color
+  const color = arrow.color ?? arrow.fromMarker.color
 
   const hasMouseEvents = onClick !== undefined || onMouseDown !== undefined
   const strokeWidth = highlighted ? 5 : 3

--- a/src/components/ArrowLine.tsx
+++ b/src/components/ArrowLine.tsx
@@ -1,4 +1,5 @@
 import React, { MouseEvent } from 'react'
+import { useCssColor } from '../colors'
 import { arrowAngleForPoints, pointArrayForArrow } from '../geometry'
 import { Arrow, UnfinishedArrow } from '../types'
 
@@ -23,7 +24,7 @@ export default function ArrowLine({
   const endPoint = points[points.length - 1]
   const arrowAngle = arrowAngleForPoints(points)
   const pointsString = points.map(({ x, y }) => `${x},${y}`).join(' ')
-  const color = arrow.color ?? arrow.fromMarker.color
+  const color = useCssColor(arrow.color ?? arrow.fromMarker.color)
 
   const hasMouseEvents = onClick !== undefined || onMouseDown !== undefined
   const strokeWidth = highlighted ? 5 : 3

--- a/src/components/Code.tsx
+++ b/src/components/Code.tsx
@@ -1,5 +1,6 @@
 import React, { Fragment } from 'react'
 import { shallowEqual } from 'react-redux'
+import { Color } from '../colors'
 import { toggleLineAnnotation } from '../reducer'
 import { useDispatch, useSelector } from '../store'
 
@@ -42,9 +43,9 @@ function Annotations({
   annotations,
   toggleAnnotation,
 }: {
-  colors: string[]
+  colors: Color[]
   annotations: Record<string, boolean>
-  toggleAnnotation: (color: string) => void
+  toggleAnnotation: (color: Color) => void
 }) {
   return (
     <div className='line-annotations'>

--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
+import { Color, useCssColor } from '../colors'
 
 type Props = {
-  colors: string[]
-  onSelect: (color: string) => void
-  selectedColor?: string
+  colors: Color[]
+  onSelect: (color: Color) => void
+  selectedColor?: Color
 }
 
 export default function ColorPicker({
@@ -30,15 +31,16 @@ function ColorButton({
   onClick,
   selected,
 }: {
-  color: string
+  color: Color
   onClick: () => void
   selected: boolean
 }) {
+  const cssColor = useCssColor(color)
   return (
     <button
       className={`color-button ${selected ? 'color-button--selected' : ''}`}
       onClick={onClick}
-      style={{ '--color': color } as React.CSSProperties}
+      style={{ '--color': cssColor } as React.CSSProperties}
     />
   )
 }

--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import { Color, useCssColor } from '../colors'
+import { Color } from '../colors'
+import useCssColor from '../hooks/useCssColor'
 
 type Props = {
   colors: Color[]

--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+
+type Props = {
+  colors: string[]
+  onSelect: (color: string) => void
+}
+
+export default function ColorPicker({ colors, onSelect }: Props) {
+  return (
+    <div className='color-picker'>
+      {colors.map((color) => (
+        <ColorButton
+          color={color}
+          onClick={() => onSelect(color)}
+          key={color}
+        />
+      ))}
+    </div>
+  )
+}
+
+function ColorButton({
+  color,
+  onClick,
+}: {
+  color: string
+  onClick: () => void
+}) {
+  return (
+    <button
+      className='color-button'
+      onClick={onClick}
+      style={{ '--color': color } as React.CSSProperties}
+    />
+  )
+}

--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -3,15 +3,21 @@ import React from 'react'
 type Props = {
   colors: string[]
   onSelect: (color: string) => void
+  selectedColor?: string
 }
 
-export default function ColorPicker({ colors, onSelect }: Props) {
+export default function ColorPicker({
+  colors,
+  onSelect,
+  selectedColor,
+}: Props) {
   return (
     <div className='color-picker'>
       {colors.map((color) => (
         <ColorButton
           color={color}
           onClick={() => onSelect(color)}
+          selected={selectedColor === color}
           key={color}
         />
       ))}
@@ -22,13 +28,15 @@ export default function ColorPicker({ colors, onSelect }: Props) {
 function ColorButton({
   color,
   onClick,
+  selected,
 }: {
   color: string
   onClick: () => void
+  selected: boolean
 }) {
   return (
     <button
-      className='color-button'
+      className={`color-button ${selected ? 'color-button--selected' : ''}`}
       onClick={onClick}
       style={{ '--color': color } as React.CSSProperties}
     />

--- a/src/components/Controls.tsx
+++ b/src/components/Controls.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react'
+import { Brightness } from '../colors'
 import { useFilePath } from '../hooks/useFile'
-import { setShowStraightArrows } from '../reducer'
+import { setAnnotationBrightness, setShowStraightArrows } from '../reducer'
 import { useDispatch, useSelector } from '../store'
 import { redo, reset, undo, useCanUndoRedo } from '../undoable'
 import Export from './Export'
@@ -19,8 +20,48 @@ export default function Controls() {
       />
       <label htmlFor='straight-arrows'>Use straight arrows</label>
       <UndoManagement />
+      <AnnotationBrightness />
       <Export />
       {import.meta.env.DEV && <PersistedStateDebugging />}
+    </div>
+  )
+}
+
+function AnnotationBrightness() {
+  const dispatch = useDispatch()
+  const brightness = useSelector((state) => state.annotationBrightness)
+
+  function RadioItem({ value, title }: { value: Brightness; title: string }) {
+    const id = `annotation-brightness--${value}`
+    return (
+      <>
+        <input
+          type='radio'
+          name='annotation-brightness'
+          id={id}
+          value={value}
+          checked={brightness === value}
+          onChange={(event) =>
+            dispatch(setAnnotationBrightness(event.target.value as Brightness))
+          }
+        />
+        <label htmlFor={id}>{title}</label>
+      </>
+    )
+  }
+
+  const radios: [Brightness, string][] = [
+    ['light', 'Light'],
+    ['medium', 'Medium'],
+    ['dark', 'Dark'],
+  ]
+
+  return (
+    <div>
+      <span>Annotation brightness: </span>
+      {radios.map(([value, title]) => (
+        <RadioItem value={value} title={title} key={value} />
+      ))}
     </div>
   )
 }

--- a/src/components/MarkerRect.tsx
+++ b/src/components/MarkerRect.tsx
@@ -1,5 +1,5 @@
 import React, { MouseEvent } from 'react'
-import { useCssColor } from '../colors'
+import useCssColor from '../hooks/useCssColor'
 import { Marker } from '../types'
 
 type Props = {
@@ -20,6 +20,7 @@ export default function MarkerRect({
   onMouseUp,
 }: Props) {
   const color = useCssColor(marker.color)
+
   return (
     <rect
       x={marker.left}

--- a/src/components/MarkerRect.tsx
+++ b/src/components/MarkerRect.tsx
@@ -1,4 +1,5 @@
 import React, { MouseEvent } from 'react'
+import { useCssColor } from '../colors'
 import { Marker } from '../types'
 
 type Props = {
@@ -18,13 +19,14 @@ export default function MarkerRect({
   onMouseMove,
   onMouseUp,
 }: Props) {
+  const color = useCssColor(marker.color)
   return (
     <rect
       x={marker.left}
       y={marker.top}
       width={marker.width}
       height={marker.height}
-      fill={marker.color}
+      fill={color}
       style={{ pointerEvents: selectable ? 'auto' : 'none' }}
       onClick={onClick}
       onMouseDown={onMouseDown}

--- a/src/components/SelectionPopover.tsx
+++ b/src/components/SelectionPopover.tsx
@@ -1,6 +1,12 @@
 import React from 'react'
 import { shallowEqual } from 'react-redux'
-import { addMarker, removeArrow, removeMarker } from '../reducer'
+import {
+  addMarker,
+  removeArrow,
+  removeMarker,
+  setArrowColor,
+  setMarkerColor,
+} from '../reducer'
 import { useDispatch, useSelector } from '../store'
 import { Arrow, Marker, Point, Rect } from '../types'
 import ColorPicker from './ColorPicker'
@@ -54,6 +60,7 @@ function TextPopover({ rect }: { rect: Rect }) {
 
 function MarkerPopover({ marker }: { marker: Marker }) {
   const dispatch = useDispatch()
+  const colors = useSelector((state) => state.colors, shallowEqual)
   return (
     <Popover
       autofocus
@@ -64,15 +71,24 @@ function MarkerPopover({ marker }: { marker: Marker }) {
       className='popover--marker'
     >
       <button onClick={() => dispatch(removeMarker(marker))}>remove</button>
+      <ColorPicker
+        colors={colors}
+        onSelect={(color) => dispatch(setMarkerColor({ marker, color }))}
+      />
     </Popover>
   )
 }
 
 function ArrowPopover({ arrow, point }: { arrow: Arrow; point: Point }) {
   const dispatch = useDispatch()
+  const colors = useSelector((state) => state.colors, shallowEqual)
   return (
     <Popover autofocus origin={point} className='popover--arrow'>
       <button onClick={() => dispatch(removeArrow(arrow))}>remove</button>
+      <ColorPicker
+        colors={colors}
+        onSelect={(color) => dispatch(setArrowColor({ arrow, color }))}
+      />
     </Popover>
   )
 }

--- a/src/components/SelectionPopover.tsx
+++ b/src/components/SelectionPopover.tsx
@@ -3,6 +3,7 @@ import { shallowEqual } from 'react-redux'
 import { addMarker, removeArrow, removeMarker } from '../reducer'
 import { useDispatch, useSelector } from '../store'
 import { Arrow, Marker, Point, Rect } from '../types'
+import ColorPicker from './ColorPicker'
 import { Popover } from './Popover'
 
 export default function SelectionPopover() {
@@ -43,14 +44,10 @@ function TextPopover({ rect }: { rect: Rect }) {
         y: rect.bottom,
       }}
     >
-      {colors.map((color) => (
-        <button
-          key={color}
-          className='color-button'
-          style={{ '--color': color } as React.CSSProperties}
-          onClick={() => dispatch(addMarker({ rect, color }))}
-        />
-      ))}
+      <ColorPicker
+        colors={colors}
+        onSelect={(color) => dispatch(addMarker({ rect, color }))}
+      />
     </Popover>
   )
 }

--- a/src/components/SelectionPopover.tsx
+++ b/src/components/SelectionPopover.tsx
@@ -74,6 +74,7 @@ function MarkerPopover({ marker }: { marker: Marker }) {
       <ColorPicker
         colors={colors}
         onSelect={(color) => dispatch(setMarkerColor({ marker, color }))}
+        selectedColor={marker.color}
       />
     </Popover>
   )
@@ -88,6 +89,7 @@ function ArrowPopover({ arrow, point }: { arrow: Arrow; point: Point }) {
       <ColorPicker
         colors={colors}
         onSelect={(color) => dispatch(setArrowColor({ arrow, color }))}
+        selectedColor={arrow.color ?? arrow.fromMarker.color}
       />
     </Popover>
   )

--- a/src/hooks/useCssColor.ts
+++ b/src/hooks/useCssColor.ts
@@ -1,0 +1,7 @@
+import { Color, cssColorFromColor } from '../colors'
+import { useSelector } from '../store'
+
+export default function useCssColor(color: Color) {
+  const brightness = useSelector((state) => state.annotationBrightness)
+  return cssColorFromColor(color, brightness)
+}

--- a/src/index.scss
+++ b/src/index.scss
@@ -102,7 +102,8 @@ body {
 
 .color-picker {
   display: grid;
-  grid-template-columns: repeat(4, auto);
+  grid-auto-flow: column;
+  grid-template-rows: repeat(4, auto);
 }
 
 .code-container {

--- a/src/index.scss
+++ b/src/index.scss
@@ -80,6 +80,29 @@ body {
   border: 0;
   background: var(--color);
   border-radius: 0.125rem;
+  position: relative;
+
+  &--selected {
+    &:after {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: radial-gradient(
+        circle at center,
+        white 0%,
+        white 25%,
+        rgba(0, 0, 0, 0) 25%
+      );
+    }
+  }
+}
+
+.color-picker {
+  display: grid;
+  grid-template-columns: repeat(4, auto);
 }
 
 .code-container {

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -71,6 +71,32 @@ const { reducer, actions } = createSlice({
     addArrow(state, action: PayloadAction<Arrow>) {
       state.arrows.push(action.payload)
     },
+    setMarkerColor(
+      state,
+      action: PayloadAction<{ marker: Marker; color: string }>,
+    ) {
+      const marker = state.markers.find(
+        ({ id }) => id === action.payload.marker.id,
+      )
+      if (!marker) {
+        return
+      }
+      marker.color = action.payload.color
+      state.currentSelection = null
+    },
+    setArrowColor(
+      state,
+      action: PayloadAction<{ arrow: Arrow; color: string }>,
+    ) {
+      const arrow = state.arrows.find(
+        ({ id }) => id === action.payload.arrow.id,
+      )
+      if (!arrow) {
+        return
+      }
+      arrow.color = action.payload.color
+      state.currentSelection = null
+    },
     toggleLineAnnotation(
       state,
       {
@@ -103,6 +129,8 @@ export const {
   addArrow,
   selectArrow,
   removeArrow,
+  setMarkerColor,
+  setArrowColor,
   clearSelection,
   toggleLineAnnotation,
   setShowStraightArrows,
@@ -114,6 +142,8 @@ const undoableActions: Set<string> = new Set([
   addArrow.type,
   removeArrow.type,
   toggleLineAnnotation.type,
+  setMarkerColor.type,
+  setArrowColor.type,
 ])
 
 export function isUndoableAction(action: AnyAction): boolean {

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -1,5 +1,6 @@
 import { AnyAction, createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { v4 as uuid } from 'uuid'
+import { Color, colors } from './colors'
 import { Arrow, Marker, Point, Rect } from './types'
 
 export type State = {
@@ -7,8 +8,8 @@ export type State = {
   currentSelection: Selection | null
   markers: Marker[]
   arrows: Arrow[]
-  lineAnnotations: Record<number, Record<string, boolean>>
-  colors: string[]
+  lineAnnotations: Record<number, Record<Color, boolean>>
+  colors: Color[]
   showStraightArrows: boolean
 }
 
@@ -23,7 +24,7 @@ const initialState: State = {
   markers: [],
   arrows: [],
   lineAnnotations: {},
-  colors: ['lightblue', 'lightgreen', 'gold', 'pink'],
+  colors: colors as unknown as Color[],
   showStraightArrows: false,
 }
 
@@ -57,7 +58,7 @@ const { reducer, actions } = createSlice({
       state.arrows = removeArrowsWithDependency(state.arrows, action.payload.id)
       state.currentSelection = null
     },
-    addMarker(state, action: PayloadAction<{ rect: Rect; color: string }>) {
+    addMarker(state, action: PayloadAction<{ rect: Rect; color: Color }>) {
       if (state.currentSelection?.type === 'text') {
         document.getSelection()?.removeAllRanges()
       }
@@ -73,7 +74,7 @@ const { reducer, actions } = createSlice({
     },
     setMarkerColor(
       state,
-      action: PayloadAction<{ marker: Marker; color: string }>,
+      action: PayloadAction<{ marker: Marker; color: Color }>,
     ) {
       const marker = state.markers.find(
         ({ id }) => id === action.payload.marker.id,
@@ -86,7 +87,7 @@ const { reducer, actions } = createSlice({
     },
     setArrowColor(
       state,
-      action: PayloadAction<{ arrow: Arrow; color: string }>,
+      action: PayloadAction<{ arrow: Arrow; color: Color }>,
     ) {
       const arrow = state.arrows.find(
         ({ id }) => id === action.payload.arrow.id,
@@ -101,7 +102,7 @@ const { reducer, actions } = createSlice({
       state,
       {
         payload: { lineNumber, color },
-      }: PayloadAction<{ lineNumber: number; color: string }>,
+      }: PayloadAction<{ lineNumber: number; color: Color }>,
     ) {
       const selectedColors = state.lineAnnotations[lineNumber] ?? {}
       selectedColors[color] = !(selectedColors[color] ?? false)

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -1,6 +1,6 @@
 import { AnyAction, createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { v4 as uuid } from 'uuid'
-import { Color, colors } from './colors'
+import { Brightness, Color, colors } from './colors'
 import { Arrow, Marker, Point, Rect } from './types'
 
 export type State = {
@@ -10,6 +10,7 @@ export type State = {
   arrows: Arrow[]
   lineAnnotations: Record<number, Record<Color, boolean>>
   colors: Color[]
+  annotationBrightness: Brightness
   showStraightArrows: boolean
 }
 
@@ -25,6 +26,7 @@ const initialState: State = {
   arrows: [],
   lineAnnotations: {},
   colors: colors as unknown as Color[],
+  annotationBrightness: 'medium',
   showStraightArrows: false,
 }
 
@@ -111,6 +113,9 @@ const { reducer, actions } = createSlice({
     setShowStraightArrows(state, action: PayloadAction<boolean>) {
       state.showStraightArrows = action.payload
     },
+    setAnnotationBrightness(state, action: PayloadAction<Brightness>) {
+      state.annotationBrightness = action.payload
+    },
   },
 })
 
@@ -135,6 +140,7 @@ export const {
   clearSelection,
   toggleLineAnnotation,
   setShowStraightArrows,
+  setAnnotationBrightness,
 } = actions
 
 const undoableActions: Set<string> = new Set([
@@ -145,6 +151,7 @@ const undoableActions: Set<string> = new Set([
   toggleLineAnnotation.type,
   setMarkerColor.type,
   setArrowColor.type,
+  setAnnotationBrightness.type,
 ])
 
 export function isUndoableAction(action: AnyAction): boolean {
@@ -165,6 +172,7 @@ export function undoableSlice({
   arrows,
   lineAnnotations,
   colors,
+  annotationBrightness,
 }: State) {
-  return { markers, arrows, lineAnnotations, colors }
+  return { markers, arrows, lineAnnotations, colors, annotationBrightness }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ export type UnfinishedArrow = {
   midPoints: Point[]
   toPoint: Point
   toMarker: Marker | null
+  color?: string
   dependencies: Record<string, boolean>
 }
 
@@ -32,6 +33,7 @@ export type Arrow = {
   midPoints: Point[]
   toPoint: Point
   toMarker: Marker
+  color?: string
   id: string
   dependencies: Record<string, boolean>
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { Color } from './colors'
+
 export type Point = { x: number; y: number }
 
 export type Rect = {
@@ -14,7 +16,7 @@ export type Selection = Rect & {
 }
 
 export type Marker = Selection & {
-  color: string
+  color: Color
 }
 
 export type UnfinishedArrow = {
@@ -23,7 +25,7 @@ export type UnfinishedArrow = {
   midPoints: Point[]
   toPoint: Point
   toMarker: Marker | null
-  color?: string
+  color?: Color
   dependencies: Record<string, boolean>
 }
 
@@ -33,7 +35,7 @@ export type Arrow = {
   midPoints: Point[]
   toPoint: Point
   toMarker: Marker
-  color?: string
+  color?: Color
   id: string
   dependencies: Record<string, boolean>
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -52,3 +52,7 @@ export function pointFromEvent(
     y: event.clientY - containerRect.top,
   }
 }
+
+// via https://stackoverflow.com/a/51399781/3813902
+export type ArrayElement<ArrayType extends readonly unknown[]> =
+  ArrayType extends readonly (infer ElementType)[] ? ElementType : never


### PR DESCRIPTION
This resolves #3 and does a little bit extra.

Specifically:

1. There are now 16 color options (courtesy of [Material Design](https://material.io/design/color/the-color-system.html#tools-for-picking-colors)). There's also a brightness control at the top of the page.
2. You can change the color of markers/arrows after you've added them. There's even a little indicator for the current color in the color picker when you change the color of a marker/arrow. (it's the little white dot in the screenshot below)

![Screen Shot 2021-08-18 at 18 26 31](https://user-images.githubusercontent.com/777023/129926273-2bab0e18-ab01-4d68-b427-810fa5c4595b.png)

## Marker duplication

There's a bug where arrows copy markers instead of referencing them. In the context of this PR this means that when you update a marker's color the arrows that start in it don't update their color. There's no other effect as far as I'm aware, apart from bloat in local storage. This bug will be fixed in the upcoming Big Refactor.

## Color variants

We're using the Material Design color palettes which come in many brightness variants (50, 100, 200, 300, ..., 900). Right now we're using the 100, 200, and 300 variants for the light, medium, and dark annotation brightness options. When we eventually add dark mode (#7)

## Migrating previous colors

Before this PR the colors we used for markers and arrows were the `gold`, `pink`, `lightblue`, and `lightgreen` web colors. Right now the old colors that are already used in localStorage are "translated" to the Material Design colors manually but it's not super nice. I'd like to actually migrate them in localStorage. This will probably happen in the Big Refactor.