### PR TITLE
Fix wrong line annotation colors in the gutter

### DIFF
--- a/src/components/Code.tsx
+++ b/src/components/Code.tsx
@@ -1,16 +1,16 @@
 import React, { Fragment } from 'react'
 import { shallowEqual } from 'react-redux'
 import { Color } from '../colors'
+import useCssColor from '../hooks/useCssColor'
 import { toggleLineAnnotation } from '../reducer'
 import { useDispatch, useSelector } from '../store'
 
 export default function Code() {
   const dispatch = useDispatch()
-  const { code, annotations, colors } = useSelector(
+  const { code, annotations } = useSelector(
     (state) => ({
       code: state.code,
       annotations: state.lineAnnotations,
-      colors: state.colors,
     }),
     shallowEqual,
   )
@@ -24,7 +24,6 @@ export default function Code() {
       {lines.map((line, index) => (
         <Fragment key={index}>
           <Annotations
-            colors={colors}
             annotations={annotations[index + 1] ?? {}}
             toggleAnnotation={(color) =>
               dispatch(toggleLineAnnotation({ lineNumber: index + 1, color }))
@@ -38,27 +37,48 @@ export default function Code() {
   )
 }
 
+const annotationColors: Color[] = ['pink', 'blue', 'green']
+
 function Annotations({
-  colors,
   annotations,
   toggleAnnotation,
 }: {
-  colors: Color[]
   annotations: Record<string, boolean>
   toggleAnnotation: (color: Color) => void
 }) {
   return (
     <div className='line-annotations'>
-      {colors.slice(0, 3).map((color) => (
-        <button
+      {annotationColors.map((color) => (
+        <AnnotationButton
           key={color}
-          onClick={() => toggleAnnotation(color)}
-          className={`color-button ${
-            annotations[color] ? 'color-button--active' : ''
-          }`}
-          style={{ '--color': color } as React.CSSProperties}
-        ></button>
+          color={color}
+          annotations={annotations}
+          toggleAnnotation={toggleAnnotation}
+        />
       ))}
     </div>
+  )
+}
+
+function AnnotationButton({
+  color,
+  annotations,
+  toggleAnnotation,
+}: {
+  color: Color
+  annotations: Record<string, boolean>
+  toggleAnnotation: (color: Color) => void
+}) {
+  const cssColor = useCssColor(color)
+
+  return (
+    <button
+      key={color}
+      onClick={() => toggleAnnotation(color)}
+      className={`color-button ${
+        annotations[color] ? 'color-button--active' : ''
+      }`}
+      style={{ '--color': cssColor } as React.CSSProperties}
+    ></button>
   )
 }


### PR DESCRIPTION
This was something I missed when I added the new annotation colors in
PR #8: I forgot to translate the Material UI color name to a hex code.