### PR TITLE
Use a context for containerRef

### DIFF
--- a/src/components/CodeAnnotations.tsx
+++ b/src/components/CodeAnnotations.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect } from 'react'
 import useArrowDrawing from '../hooks/useArrowDrawing'
+import { ContainerDiv, useContainer } from '../hooks/useContainer'
+import { useSettings } from '../hooks/useSettings'
 import useTextSelectionHandler from '../hooks/useTextSelectionHandler'
 import { selectArrow, selectMarker } from '../reducer'
-import { useSettings } from '../hooks/useSettings'
 import { useDispatch, useSelector } from '../store'
-import { pointFromEvent } from '../util'
 import ArrowLine from './ArrowLine'
 import MarkerRect from './MarkerRect'
 import SelectionPopover from './SelectionPopover'
@@ -15,7 +15,7 @@ export default function CodeAnnotations({
   numberOfLines: number
 }) {
   return (
-    <div
+    <ContainerDiv
       className='svg-container'
       style={{
         gridRow: `1 / span ${numberOfLines}`,
@@ -23,23 +23,21 @@ export default function CodeAnnotations({
     >
       <Svg />
       <SelectionPopover />
-    </div>
+    </ContainerDiv>
   )
 }
 
 function Svg() {
-  const containerRef = React.useRef<SVGSVGElement | null>(null)
   const { showStraightArrows } = useSettings()
-  const { drag, mouseEvents } = useArrowDrawing(containerRef)
+  const { drag, mouseEvents } = useArrowDrawing()
 
-  const selectionChangeHandler = useTextSelectionHandler(containerRef)
+  const selectionChangeHandler = useTextSelectionHandler()
   useEffect(() => {
     document.onselectionchange = selectionChangeHandler
   }, [selectionChangeHandler])
 
   return (
     <svg
-      ref={containerRef}
       style={{
         pointerEvents: drag ? 'auto' : 'none',
       }}
@@ -53,25 +51,22 @@ function Svg() {
           selectable={false}
         />
       )}
-      <Arrows
-        containerRef={containerRef}
-        arrowMouseEvents={mouseEvents.arrow}
-      />
+      <Arrows arrowMouseEvents={mouseEvents.arrow} />
       <Markers markerMouseEvents={mouseEvents.marker} />
     </svg>
   )
 }
 
 type ArrowsProps = {
-  containerRef: React.MutableRefObject<SVGSVGElement | null>
   arrowMouseEvents: ReturnType<typeof useArrowDrawing>['mouseEvents']['arrow']
 }
 
-function Arrows({ containerRef, arrowMouseEvents }: ArrowsProps) {
+function Arrows({ arrowMouseEvents }: ArrowsProps) {
   const dispatch = useDispatch()
   const arrows = useSelector((state) => Object.values(state.arrows))
   const { showStraightArrows } = useSettings()
   const currentSelection = useSelector((state) => state.currentSelection)
+  const { eventCoordinates } = useContainer()
 
   return (
     <>
@@ -84,7 +79,7 @@ function Arrows({ containerRef, arrowMouseEvents }: ArrowsProps) {
             dispatch(
               selectArrow({
                 arrow,
-                point: pointFromEvent(e, containerRef.current!),
+                point: eventCoordinates(e),
               }),
             )
           }

--- a/src/hooks/useContainer.tsx
+++ b/src/hooks/useContainer.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import { Point } from '../types'
+import { pointFromEvent } from '../util'
+
+const ContainerContext = React.createContext<
+  React.MutableRefObject<HTMLDivElement | null> | undefined
+>(undefined)
+ContainerContext.displayName = 'ContainerContext'
+
+export function ContainerDiv(
+  props: Omit<
+    React.DetailedHTMLProps<
+      React.HTMLAttributes<HTMLDivElement>,
+      HTMLDivElement
+    >,
+    'ref'
+  >,
+) {
+  const ref = React.useRef<HTMLDivElement | null>(null)
+  return (
+    <ContainerContext.Provider value={ref}>
+      <div {...props} ref={ref} />
+    </ContainerContext.Provider>
+  )
+}
+
+export function useContainer(): {
+  containerRef: React.MutableRefObject<HTMLDivElement | null>
+  eventCoordinates: (event: React.MouseEvent) => Point
+} {
+  const ref = React.useContext(ContainerContext)
+  if (!ref) {
+    throw new Error(`Tried to call useContainer outside of a <ContainerDiv>`)
+  }
+
+  const eventCoordinates = React.useCallback(
+    (event: React.MouseEvent) => pointFromEvent(event, ref.current!),
+    [],
+  )
+
+  return { containerRef: ref, eventCoordinates }
+}

--- a/src/hooks/useTextSelectionHandler.ts
+++ b/src/hooks/useTextSelectionHandler.ts
@@ -2,11 +2,11 @@ import React from 'react'
 import { clearSelection, selectText } from '../reducer'
 import { useDispatch, useSelector } from '../store'
 import { TextRange } from '../types'
+import { useContainer } from './useContainer'
 
-export default function useTextSelectionHandler(
-  containerRef: React.MutableRefObject<SVGSVGElement | null>,
-) {
+export default function useTextSelectionHandler() {
   const dispatch = useDispatch()
+  const { containerRef } = useContainer()
   const isTextCurrentlySelected = useSelector(
     (state) => state.currentSelection?.type === 'text',
   )


### PR DESCRIPTION
It's used in a bunch of places and I don't want to pass it through
the entire component tree
