### PR TITLE
Make inactive line annotations visible

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -56,7 +56,7 @@ body {
 
       &:not(:hover) {
         .color-button:not(.color-button--active) {
-          opacity: 0;
+          filter: grayscale(100%) brightness(0) contrast(0) brightness(1.9);
         }
       }
     }


### PR DESCRIPTION
Now line annotations are gray by default.

![output](https://user-images.githubusercontent.com/777023/147338988-f5cf1902-6b73-42e8-912a-c655a17fd052.gif)

Hopefully this will make them more discoverable