### PR TITLE
Improve keyboard event handling

### DIFF
--- a/src/hooks/useArrowDrawing.ts
+++ b/src/hooks/useArrowDrawing.ts
@@ -5,6 +5,7 @@ import { addArrow } from '../reducer'
 import { useDispatch } from '../store'
 import { Arrow, Marker, Point, UnfinishedArrow } from '../types'
 import { useContainer } from './useContainer'
+import useKeyboardHandler from './useKeyboardHandler'
 import { useSettings } from './useSettings'
 
 type SvgMouseEvents = {
@@ -36,6 +37,13 @@ export default function useArrowDrawing(): ReturnType {
   const [drag, setDrag] = React.useState<UnfinishedArrow | null>(null)
   const { showStraightArrows } = useSettings()
   const dispatch = useDispatch()
+
+  const escapeKeyHandler = React.useCallback((event: KeyboardEvent) => {
+    if (event.key === 'Escape') {
+      setDrag(null)
+    }
+  }, [])
+  useKeyboardHandler(escapeKeyHandler)
 
   const onMouseDown = useCallback(
     (event: MouseEvent, target: Marker | Arrow) => {

--- a/src/hooks/useKeyboardHandler.ts
+++ b/src/hooks/useKeyboardHandler.ts
@@ -1,52 +1,21 @@
-import { useCallback } from 'react'
-import { clearSelection, removeArrow, removeMarker } from '../reducer'
-import { useDispatch, useSelector } from '../store'
-import { redo, undo } from '../undoable'
+import React from 'react'
 
-export default function useKeyboardHandler() {
-  const dispatch = useDispatch()
-  const currentSelection = useSelector((state) => state.currentSelection)
+// with a little help from https://stackoverflow.com/a/57926311
+export default function useKeyboardHandler(
+  handler: (event: KeyboardEvent) => void,
+) {
+  const handlerRef = React.useRef(handler)
 
-  const handler = useCallback(
-    (event: KeyboardEvent) => {
-      const isMetaOn = event.ctrlKey || event.metaKey
-      if (event.key === 'z' && isMetaOn && event.shiftKey) {
-        // redo
-        event.preventDefault()
-        event.stopPropagation()
-        dispatch(redo())
-      } else if (event.key === 'z' && isMetaOn) {
-        // undo
-        event.preventDefault()
-        event.stopPropagation()
-        dispatch(undo())
-      } else if (
-        ['Backspace', 'Delete'].includes(event.key) &&
-        currentSelection
-      ) {
-        // remove currently selected marker/arrow
-        switch (currentSelection.type) {
-          case 'text': {
-            return
-          }
-          case 'marker': {
-            dispatch(removeMarker(currentSelection.marker))
-            return
-          }
-          case 'arrow': {
-            dispatch(removeArrow(currentSelection.arrow))
-            return
-          }
-        }
-      } else if (event.key === 'Escape' && currentSelection) {
-        dispatch(clearSelection())
-        if (currentSelection.type === 'text') {
-          document.getSelection()?.removeAllRanges()
-        }
-      }
-    },
-    [dispatch, currentSelection],
-  )
+  React.useEffect(() => {
+    handlerRef.current = handler
+  }, [handler])
 
-  return handler
+  React.useEffect(() => {
+    const eventListener = (event: KeyboardEvent) => handlerRef.current(event)
+    document.addEventListener('keydown', eventListener)
+
+    return () => {
+      document.removeEventListener('keydown', eventListener)
+    }
+  }, [])
 }


### PR DESCRIPTION
Fix the keyboard handler hook to allow multiple instances: Instead of setting `document.onkeyup = ...`, now it's using `document.addEventListener('keyup', ...)`.

That way we can have multiple listeners, which now allows us to attach keyboard events to the arrow drawing hook: when you hit escape while drawing it cancels the arrow.

In the future I'd like to add more keyboard shortcuts to make the annotation tool easier to use without a mouse, and this should help with that :)