### PR TITLE
Some arrow drawing related things

### DIFF
--- a/src/components/ArrowLine.tsx
+++ b/src/components/ArrowLine.tsx
@@ -6,7 +6,6 @@ import { Arrow, UnfinishedArrow } from '../types'
 
 type Props = {
   arrow: Arrow | UnfinishedArrow
-  straight: boolean
   highlighted?: boolean
   selectable: boolean
   onClick?: (event: MouseEvent) => void
@@ -15,7 +14,6 @@ type Props = {
 
 export default function ArrowLine({
   arrow,
-  straight,
   highlighted = false,
   selectable,
   onClick,
@@ -24,13 +22,8 @@ export default function ArrowLine({
   const toMarker = useSelector((state) =>
     arrow.toMarker ? state.markers[arrow.toMarker] : null,
   )
-  const points = pointArrayForArrow(
-    arrow.fromPoint,
-    arrow.midPoints,
-    arrow.toPoint,
-    toMarker,
-    straight,
-  )
+  const points = pointArrayForArrow(arrow, toMarker)
+
   const endPoint = points[points.length - 1]
   const arrowAngle = arrowAngleForPoints(points)
   const pointsString = points.map(({ x, y }) => `${x},${y}`).join(' ')

--- a/src/components/CodeAnnotations.tsx
+++ b/src/components/CodeAnnotations.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react'
 import useArrowDrawing from '../hooks/useArrowDrawing'
 import { ContainerDiv, useContainer } from '../hooks/useContainer'
-import { useSettings } from '../hooks/useSettings'
 import useTextSelectionHandler from '../hooks/useTextSelectionHandler'
 import { selectArrow, selectMarker } from '../reducer'
 import { useDispatch, useSelector } from '../store'
@@ -28,7 +27,6 @@ export default function CodeAnnotations({
 }
 
 function Svg() {
-  const { showStraightArrows } = useSettings()
   const { drag, mouseEvents } = useArrowDrawing()
 
   const selectionChangeHandler = useTextSelectionHandler()
@@ -44,13 +42,7 @@ function Svg() {
       onMouseMove={(e) => mouseEvents.svg.onMouseMove(e)}
       onMouseUp={(e) => mouseEvents.svg.onMouseUp(e)}
     >
-      {drag && (
-        <ArrowLine
-          arrow={drag}
-          straight={showStraightArrows}
-          selectable={false}
-        />
-      )}
+      {drag && <ArrowLine arrow={drag} selectable={false} />}
       <Arrows arrowMouseEvents={mouseEvents.arrow} />
       <Markers markerMouseEvents={mouseEvents.marker} />
     </svg>
@@ -64,7 +56,6 @@ type ArrowsProps = {
 function Arrows({ arrowMouseEvents }: ArrowsProps) {
   const dispatch = useDispatch()
   const arrows = useSelector((state) => Object.values(state.arrows))
-  const { showStraightArrows } = useSettings()
   const currentSelection = useSelector((state) => state.currentSelection)
   const { eventCoordinates } = useContainer()
 
@@ -73,7 +64,6 @@ function Arrows({ arrowMouseEvents }: ArrowsProps) {
       {arrows.map((arrow) => (
         <ArrowLine
           arrow={arrow}
-          straight={showStraightArrows}
           selectable={currentSelection?.type !== 'text'}
           onClick={(e) =>
             dispatch(

--- a/src/components/CodeAnnotations.tsx
+++ b/src/components/CodeAnnotations.tsx
@@ -27,7 +27,7 @@ export default function CodeAnnotations({
 }
 
 function Svg() {
-  const { drag, mouseEvents } = useArrowDrawing()
+  const { currentArrow, mouseEvents } = useArrowDrawing()
 
   const selectionChangeHandler = useTextSelectionHandler()
   useEffect(() => {
@@ -37,12 +37,12 @@ function Svg() {
   return (
     <svg
       style={{
-        pointerEvents: drag ? 'auto' : 'none',
+        pointerEvents: currentArrow ? 'auto' : 'none',
       }}
       onMouseMove={(e) => mouseEvents.svg.onMouseMove(e)}
       onMouseUp={(e) => mouseEvents.svg.onMouseUp(e)}
     >
-      {drag && <ArrowLine arrow={drag} selectable={false} />}
+      {currentArrow && <ArrowLine arrow={currentArrow} selectable={false} />}
       <Arrows arrowMouseEvents={mouseEvents.arrow} />
       <Markers markerMouseEvents={mouseEvents.marker} />
     </svg>

--- a/src/geometry.ts
+++ b/src/geometry.ts
@@ -1,4 +1,4 @@
-import { Marker, Point, Rect } from './types'
+import { Arrow, Marker, Point, Rect, UnfinishedArrow } from './types'
 import { findLast, isMonotonous, minBy } from './util'
 
 export function distanceBetweenPoints(a: Point, b: Point): number {
@@ -6,15 +6,10 @@ export function distanceBetweenPoints(a: Point, b: Point): number {
 }
 
 export function pointArrayForArrow(
-  fromPoint: Point,
-  midPoints: Point[],
-  toPoint: Point,
+  arrow: Arrow | UnfinishedArrow,
   toMarker: Marker | null,
-  straight: boolean,
 ): Point[] {
-  const allPoints = straight
-    ? [fromPoint, toPoint]
-    : [fromPoint, ...midPoints, toPoint]
+  const allPoints = [arrow.fromPoint, ...arrow.midPoints, arrow.toPoint]
 
   if (!toMarker || allPoints.every((pt) => !isPointInRect(pt, toMarker))) {
     return allPoints

--- a/src/geometry.ts
+++ b/src/geometry.ts
@@ -1,5 +1,5 @@
 import { Arrow, Marker, Point, Rect, UnfinishedArrow } from './types'
-import { findLast, isMonotonous, minBy, pairs } from './util'
+import { findLast, isMonotonous, minBy, range } from './util'
 
 export function distanceBetweenPoints(a: Point, b: Point): number {
   return Math.max(Math.abs(a.x - b.x), Math.abs(a.y - b.y))
@@ -133,6 +133,13 @@ export function pointOnPolylineNearPoint(p: Point, polyline: Point[]): Point {
   }
 
   return pointOnNearestSegment[0]
+}
+
+function pairs<T>(array: T[]): [T, T][] {
+  return range(0, array.length - 1).map((index) => [
+    array[index],
+    array[index + 1],
+  ])
 }
 
 function pointOnLineNearPoint(

--- a/src/geometry.ts
+++ b/src/geometry.ts
@@ -1,5 +1,5 @@
 import { Arrow, Marker, Point, Rect, UnfinishedArrow } from './types'
-import { findLast, isMonotonous, minBy } from './util'
+import { findLast, isMonotonous, minBy, pairs } from './util'
 
 export function distanceBetweenPoints(a: Point, b: Point): number {
   return Math.max(Math.abs(a.x - b.x), Math.abs(a.y - b.y))
@@ -120,20 +120,36 @@ function verticalLineIntersection(
   }
 }
 
-export function pointOnLineNearLine(
+export function pointOnPolylineNearPoint(p: Point, polyline: Point[]): Point {
+  const pointsOnSegments = pairs(polyline).map((segment) =>
+    pointOnLineNearPoint(...segment, p),
+  )
+
+  const pointOnNearestSegment = minBy(pointsOnSegments, (pt) =>
+    distanceBetweenPoints(p, pt),
+  )
+  if (!pointOnNearestSegment) {
+    throw new Error(`Not enough points on polyline`)
+  }
+
+  return pointOnNearestSegment[0]
+}
+
+function pointOnLineNearPoint(
   p1: Point,
   p2: Point,
   { x: x0, y: y0 }: Point,
 ): Point {
-  const a = p2.y - p1.y
-  const b = p1.x - p2.x
-  const c = p1.y * p2.x - p1.x * p2.y
+  const d = Math.sqrt(Math.pow(p1.x - p2.x, 2) + Math.pow(p1.y - p2.y, 2))
+  const n = { x: (p2.x - p1.x) / d, y: (p2.y - p1.y) / d }
+  const t0 = (x0 - p1.x) * n.x + (y0 - p1.y) * n.y
+  if (t0 <= 0) {
+    return p1
+  } else if (t0 >= d) {
+    return p2
+  }
 
-  const denom = a * a + b * b
-  const paren = a * y0 - b * x0
-  const x = (-b * paren - a * c) / denom
-  const y = (a * paren - b * c) / denom
-  return { x, y }
+  return { x: p1.x + t0 * n.x, y: p1.y + t0 * n.y }
 }
 
 export function isPointInRect(

--- a/src/hooks/useArrowDrawing.ts
+++ b/src/hooks/useArrowDrawing.ts
@@ -24,7 +24,7 @@ type ArrowMouseEvents = {
 }
 
 type ReturnType = {
-  drag: UnfinishedArrow | null
+  currentArrow: UnfinishedArrow | null
   mouseEvents: {
     svg: SvgMouseEvents
     marker: MarkerMouseEvents
@@ -34,13 +34,14 @@ type ReturnType = {
 
 export default function useArrowDrawing(): ReturnType {
   const { eventCoordinates } = useContainer()
-  const [drag, setDrag] = React.useState<UnfinishedArrow | null>(null)
+  const [currentArrow, setCurrentArrow] =
+    React.useState<UnfinishedArrow | null>(null)
   const { showStraightArrows } = useSettings()
   const dispatch = useDispatch()
 
   const escapeKeyHandler = React.useCallback((event: KeyboardEvent) => {
     if (event.key === 'Escape') {
-      setDrag(null)
+      setCurrentArrow(null)
     }
   }, [])
   useKeyboardHandler(escapeKeyHandler)
@@ -54,7 +55,7 @@ export default function useArrowDrawing(): ReturnType {
         showStraightArrows,
         currentPoint,
       )
-      setDrag({
+      setCurrentArrow({
         fromPoint,
         fromMarker,
         midPoints: [],
@@ -68,7 +69,7 @@ export default function useArrowDrawing(): ReturnType {
 
   const onMouseMove = useCallback(
     (event: MouseEvent, marker: Marker | null = null) => {
-      if (!drag) {
+      if (!currentArrow) {
         return
       }
 
@@ -76,56 +77,57 @@ export default function useArrowDrawing(): ReturnType {
         event.stopPropagation()
       }
 
-      const markerIsOriginMarker = marker?.id === drag.fromMarker
+      const markerIsOriginMarker = marker?.id === currentArrow.fromMarker
 
       const currentPoint = eventCoordinates(event)
       const lastPoint =
-        drag.midPoints[drag.midPoints.length - 1] ?? drag.fromPoint
+        currentArrow.midPoints[currentArrow.midPoints.length - 1] ??
+        currentArrow.fromPoint
 
       const newMidPoints =
         !showStraightArrows &&
         distanceBetweenPoints(currentPoint, lastPoint) > 10
-          ? [...drag.midPoints, currentPoint]
-          : drag.midPoints
+          ? [...currentArrow.midPoints, currentPoint]
+          : currentArrow.midPoints
 
-      setDrag({
-        ...drag,
+      setCurrentArrow({
+        ...currentArrow,
         midPoints: newMidPoints,
         toPoint: currentPoint,
         toMarker: markerIsOriginMarker ? null : marker?.id ?? null,
       })
     },
-    [eventCoordinates, drag, showStraightArrows],
+    [eventCoordinates, currentArrow, showStraightArrows],
   )
 
   const onMouseUp = useCallback(
     (event: MouseEvent, marker: Marker | null = null) => {
-      if (!drag) {
+      if (!currentArrow) {
         return
       }
 
-      if (!marker || marker.id === drag.fromMarker) {
-        setDrag(null)
+      if (!marker || marker.id === currentArrow.fromMarker) {
+        setCurrentArrow(null)
         return
       }
 
       const arrow = {
-        fromMarker: drag.fromMarker,
-        fromPoint: drag.fromPoint,
-        midPoints: drag.midPoints,
+        fromMarker: currentArrow.fromMarker,
+        fromPoint: currentArrow.fromPoint,
+        midPoints: currentArrow.midPoints,
         toMarker: marker.id,
         toPoint: eventCoordinates(event),
         id: uuid(),
-        dependencies: { ...drag.dependencies, [marker.id]: true },
+        dependencies: { ...currentArrow.dependencies, [marker.id]: true },
       }
       dispatch(addArrow(arrow))
-      setDrag(null)
+      setCurrentArrow(null)
     },
-    [eventCoordinates, drag, setDrag],
+    [eventCoordinates, currentArrow, setCurrentArrow],
   )
 
   return {
-    drag,
+    currentArrow,
     mouseEvents: {
       svg: {
         onMouseMove: (e) => onMouseMove(e),

--- a/src/hooks/useArrowDrawing.ts
+++ b/src/hooks/useArrowDrawing.ts
@@ -1,6 +1,6 @@
 import React, { MouseEvent, useCallback } from 'react'
 import { v4 as uuid } from 'uuid'
-import { distanceBetweenPoints, pointOnLineNearLine } from '../geometry'
+import { distanceBetweenPoints, pointOnPolylineNearPoint } from '../geometry'
 import { addArrow } from '../reducer'
 import { useDispatch } from '../store'
 import { Arrow, Marker, Point, UnfinishedArrow } from '../types'
@@ -63,7 +63,7 @@ export default function useArrowDrawing(): ReturnType {
         dependencies,
       })
     },
-    [eventCoordinates],
+    [eventCoordinates, showStraightArrows],
   )
 
   const onMouseMove = useCallback(
@@ -145,14 +145,16 @@ export default function useArrowDrawing(): ReturnType {
 
 function dragStartProperties(
   target: Arrow | Marker,
-  straight: boolean,
+  showStraightArrows: boolean,
   currentPoint: Point,
 ): Pick<UnfinishedArrow, 'fromPoint' | 'fromMarker' | 'dependencies'> {
   if ('fromMarker' in target) {
     return {
-      fromPoint: straight
-        ? pointOnLineNearLine(target.fromPoint, target.toPoint, currentPoint)
-        : currentPoint,
+      fromPoint: pointOnPolylineNearPoint(currentPoint, [
+        target.fromPoint,
+        ...target.midPoints,
+        target.toPoint,
+      ]),
       fromMarker: target.fromMarker,
       dependencies: {
         ...target.dependencies,

--- a/src/util.ts
+++ b/src/util.ts
@@ -24,14 +24,7 @@ export function minBy<T>(
   return [minItem, minIndex]
 }
 
-export function pairs<T>(array: T[]): [T, T][] {
-  return range(0, array.length - 1).map((index) => [
-    array[index],
-    array[index + 1],
-  ])
-}
-
-function range(min: number, max: number): number[] {
+export function range(min: number, max: number): number[] {
   if (max < min) {
     return []
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -12,16 +12,30 @@ export function minBy<T>(
   let minItem = array[minIndex]
   let minValue = value(minItem)
 
-  array.slice(1).forEach((item, index) => {
-    const currentValue = value(item)
+  range(1, array.length).map((index) => {
+    const currentValue = value(array[index])
     if (currentValue < minValue) {
       minValue = currentValue
-      minItem = item
+      minItem = array[index]
       minIndex = index
     }
   })
 
   return [minItem, minIndex]
+}
+
+export function pairs<T>(array: T[]): [T, T][] {
+  return range(0, array.length - 1).map((index) => [
+    array[index],
+    array[index + 1],
+  ])
+}
+
+function range(min: number, max: number): number[] {
+  if (max < min) {
+    return []
+  }
+  return new Array(max - min).fill(0).map((_, index) => min + index)
 }
 
 export function isMonotonous(a: number, b: number, c: number): boolean {


### PR DESCRIPTION
Three smallish changes that fell out of the work on polyline arrow drawing (for #4).

### Don't straighten freehand arrows after they've been drawn

Previously, for some reason I decided that when you checked the "use straight arrows" checkbox, the freehand arrows that were already drawn will also be shown as straight lines. This was a weird decision and I regret it. Now arrows will never change their shape after you've drawn them.

### Better nearest point detection for new arrows

When you start drawing an arrow from an existing arrow there used to be a little gap. This is because the click target for arrows includes some padding around the arrow, so events near the arrow counted as events on the arrow. When you started an arrow from that padding you got a gap.

Now, with the help of some geometry, the arrow will always start from a point on the arrow that's closest to the mouse. Rejoice.

![Artboard](https://user-images.githubusercontent.com/777023/147367464-7b4a42d6-bc50-48cc-a7a0-8d1dfe4d6e61.png)

This was done by calling `pointOnLineNearPoint` on all segments of the existing arrow and picking the closest result.

This also helped me find a bug with my `minBy` function, which was very silly and had to do with index math.

### Rename drag in the arrow drawing hook

This is a silly change but it had a big diff and I didn't want it to complicate the already complex PR that's coming soon)