### PR TITLE
Fix inactive line annotation colors when exporting as png

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -56,7 +56,7 @@ body {
 
       &:not(:hover) {
         .color-button:not(.color-button--active) {
-          filter: grayscale(100%) brightness(0) contrast(0) brightness(1.9);
+          background: #eeeeee; // overrides the default value of var(--color)
         }
       }
     }


### PR DESCRIPTION
The previous solution (#16) with the spicy filter didn't work when exporting to png because the package we use to create the png ignores filters.

The new solution:

1. works
2. is easier to understand