### PR TITLE
New mouse interactions for popovers and arrow drawing

### DIFF
--- a/src/components/ArrowLine.tsx
+++ b/src/components/ArrowLine.tsx
@@ -105,9 +105,10 @@ export function FinishedArrowLine({
   const onContextMenu = React.useCallback(
     (event: MouseEvent) => {
       event.preventDefault()
+      drawing.cancelArrow()
       dispatch(selectArrow({ arrow, point: eventCoordinates(event) }))
     },
-    [eventCoordinates],
+    [eventCoordinates, drawing.cancelArrow],
   )
 
   return (

--- a/src/components/CodeAnnotations.tsx
+++ b/src/components/CodeAnnotations.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect } from 'react'
 import {
   ArrowDrawingProvider,
-  useArrowDrawingEventHandlers,
   useCurrentArrowDrawing,
+  useDrawingEventHandlers,
 } from '../hooks/useArrowDrawing'
 import { ContainerDiv } from '../hooks/useContainer'
 import useTextSelectionHandler from '../hooks/useTextSelectionHandler'
@@ -33,7 +33,7 @@ export default function CodeAnnotations({
 
 function Svg() {
   const currentArrow = useCurrentArrowDrawing()
-  const { svgMouseEvents } = useArrowDrawingEventHandlers()
+  const drawing = useDrawingEventHandlers()
 
   const selectionChangeHandler = useTextSelectionHandler()
   useEffect(() => {
@@ -45,8 +45,8 @@ function Svg() {
       style={{
         pointerEvents: currentArrow ? 'auto' : 'none',
       }}
-      onMouseMove={(e) => svgMouseEvents.onMouseMove(e)}
-      onMouseUp={(e) => svgMouseEvents.onMouseUp(e)}
+      onMouseMove={(event) => drawing.onMouseMove(event, null)}
+      onClick={(event) => drawing.onClick(event, null)}
     >
       <UnfinishedArrowLine />
       <Arrows />

--- a/src/components/CodeAnnotations.tsx
+++ b/src/components/CodeAnnotations.tsx
@@ -4,11 +4,10 @@ import {
   useArrowDrawingEventHandlers,
   useCurrentArrowDrawing,
 } from '../hooks/useArrowDrawing'
-import { ContainerDiv, useContainer } from '../hooks/useContainer'
+import { ContainerDiv } from '../hooks/useContainer'
 import useTextSelectionHandler from '../hooks/useTextSelectionHandler'
-import { selectArrow, selectMarker } from '../reducer'
-import { useDispatch, useSelector } from '../store'
-import ArrowLine from './ArrowLine'
+import { useSelector } from '../store'
+import { FinishedArrowLine, UnfinishedArrowLine } from './ArrowLine'
 import MarkerRect from './MarkerRect'
 import SelectionPopover from './SelectionPopover'
 
@@ -49,7 +48,7 @@ function Svg() {
       onMouseMove={(e) => svgMouseEvents.onMouseMove(e)}
       onMouseUp={(e) => svgMouseEvents.onMouseUp(e)}
     >
-      {currentArrow && <ArrowLine arrow={currentArrow} selectable={false} />}
+      <UnfinishedArrowLine />
       <Arrows />
       <Markers />
     </svg>
@@ -57,27 +56,15 @@ function Svg() {
 }
 
 function Arrows() {
-  const dispatch = useDispatch()
-  const { arrowMouseEvents } = useArrowDrawingEventHandlers()
   const arrows = useSelector((state) => Object.values(state.arrows))
   const currentSelection = useSelector((state) => state.currentSelection)
-  const { eventCoordinates } = useContainer()
 
   return (
     <>
       {arrows.map((arrow) => (
-        <ArrowLine
+        <FinishedArrowLine
           arrow={arrow}
           selectable={currentSelection?.type !== 'text'}
-          onClick={(e) =>
-            dispatch(
-              selectArrow({
-                arrow,
-                point: eventCoordinates(e),
-              }),
-            )
-          }
-          onMouseDown={(e) => arrowMouseEvents.onMouseDown(e, arrow)}
           highlighted={
             currentSelection?.type === 'arrow' &&
             (arrow.id === currentSelection.arrow.id ||
@@ -91,8 +78,6 @@ function Arrows() {
 }
 
 function Markers() {
-  const dispatch = useDispatch()
-  const { markerMouseEvents } = useArrowDrawingEventHandlers()
   const markers = useSelector((state) => Object.values(state.markers))
   const currentSelection = useSelector((state) => state.currentSelection)
 
@@ -103,10 +88,6 @@ function Markers() {
           key={marker.id}
           marker={marker}
           selectable={currentSelection?.type !== 'text'}
-          onClick={() => dispatch(selectMarker(marker))}
-          onMouseDown={(e) => markerMouseEvents.onMouseDown(e, marker)}
-          onMouseMove={(e) => markerMouseEvents.onMouseMove(e, marker)}
-          onMouseUp={(e) => markerMouseEvents.onMouseUp(e, marker)}
         />
       ))}
     </>

--- a/src/components/CodeAnnotations.tsx
+++ b/src/components/CodeAnnotations.tsx
@@ -1,5 +1,9 @@
 import React, { useEffect } from 'react'
-import useArrowDrawing from '../hooks/useArrowDrawing'
+import {
+  ArrowDrawingProvider,
+  useArrowDrawingEventHandlers,
+  useCurrentArrowDrawing,
+} from '../hooks/useArrowDrawing'
 import { ContainerDiv, useContainer } from '../hooks/useContainer'
 import useTextSelectionHandler from '../hooks/useTextSelectionHandler'
 import { selectArrow, selectMarker } from '../reducer'
@@ -20,14 +24,17 @@ export default function CodeAnnotations({
         gridRow: `1 / span ${numberOfLines}`,
       }}
     >
-      <Svg />
-      <SelectionPopover />
+      <ArrowDrawingProvider>
+        <Svg />
+        <SelectionPopover />
+      </ArrowDrawingProvider>
     </ContainerDiv>
   )
 }
 
 function Svg() {
-  const { currentArrow, mouseEvents } = useArrowDrawing()
+  const currentArrow = useCurrentArrowDrawing()
+  const { svgMouseEvents } = useArrowDrawingEventHandlers()
 
   const selectionChangeHandler = useTextSelectionHandler()
   useEffect(() => {
@@ -39,22 +46,19 @@ function Svg() {
       style={{
         pointerEvents: currentArrow ? 'auto' : 'none',
       }}
-      onMouseMove={(e) => mouseEvents.svg.onMouseMove(e)}
-      onMouseUp={(e) => mouseEvents.svg.onMouseUp(e)}
+      onMouseMove={(e) => svgMouseEvents.onMouseMove(e)}
+      onMouseUp={(e) => svgMouseEvents.onMouseUp(e)}
     >
       {currentArrow && <ArrowLine arrow={currentArrow} selectable={false} />}
-      <Arrows arrowMouseEvents={mouseEvents.arrow} />
-      <Markers markerMouseEvents={mouseEvents.marker} />
+      <Arrows />
+      <Markers />
     </svg>
   )
 }
 
-type ArrowsProps = {
-  arrowMouseEvents: ReturnType<typeof useArrowDrawing>['mouseEvents']['arrow']
-}
-
-function Arrows({ arrowMouseEvents }: ArrowsProps) {
+function Arrows() {
   const dispatch = useDispatch()
+  const { arrowMouseEvents } = useArrowDrawingEventHandlers()
   const arrows = useSelector((state) => Object.values(state.arrows))
   const currentSelection = useSelector((state) => state.currentSelection)
   const { eventCoordinates } = useContainer()
@@ -86,12 +90,9 @@ function Arrows({ arrowMouseEvents }: ArrowsProps) {
   )
 }
 
-type MarkersProps = {
-  markerMouseEvents: ReturnType<typeof useArrowDrawing>['mouseEvents']['marker']
-}
-
-function Markers({ markerMouseEvents }: MarkersProps) {
+function Markers() {
   const dispatch = useDispatch()
+  const { markerMouseEvents } = useArrowDrawingEventHandlers()
   const markers = useSelector((state) => Object.values(state.markers))
   const currentSelection = useSelector((state) => state.currentSelection)
 

--- a/src/components/CodeAnnotations.tsx
+++ b/src/components/CodeAnnotations.tsx
@@ -25,6 +25,7 @@ export default function CodeAnnotations({
     >
       <ArrowDrawingProvider>
         <Svg />
+        <DrawingCancelationButton />
         <SelectionPopover />
       </ArrowDrawingProvider>
     </ContainerDiv>
@@ -91,5 +92,21 @@ function Markers() {
         />
       ))}
     </>
+  )
+}
+
+function DrawingCancelationButton() {
+  const currentArrow = useCurrentArrowDrawing()
+  const drawing = useDrawingEventHandlers()
+  if (!currentArrow) {
+    return null
+  }
+  return (
+    <button
+      className='drawing-cancelation-button'
+      onClick={() => drawing.cancelArrow()}
+    >
+      To cancel the current arrow, hit <kbd>esc</kbd> or click here
+    </button>
   )
 }

--- a/src/components/Controls.tsx
+++ b/src/components/Controls.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react'
 import { Brightness } from '../colors'
-import { useSettings } from '../hooks/useSettings'
+import { ArrowDrawingMode, useSettings } from '../hooks/useSettings'
 import useSource from '../hooks/useSource'
 import { localStorageKey } from '../source'
 import { useDispatch } from '../store'
@@ -9,17 +9,11 @@ import Export from './Export'
 
 export default function Controls() {
   const dispatch = useDispatch()
-  const { showStraightArrows, setShowStraightArrows } = useSettings()
+  const { arrowDrawingMode, setArrowDrawingMode } = useSettings()
 
   return (
     <div className='annotation-controls'>
-      <input
-        type='checkbox'
-        id='straight-arrows'
-        checked={showStraightArrows}
-        onChange={(e) => setShowStraightArrows(e.target.checked)}
-      />
-      <label htmlFor='straight-arrows'>Use straight arrows</label>
+      <DrawingMode />
       <UndoManagement />
       <AnnotationBrightness />
       <Export />
@@ -28,41 +22,45 @@ export default function Controls() {
   )
 }
 
+const drawingModeOptions: { title: string; value: ArrowDrawingMode }[] = [
+  { title: 'Freehand', value: 'freehand' },
+  { title: 'Jointed', value: 'jointed' },
+]
+
+function DrawingMode() {
+  const { arrowDrawingMode, setArrowDrawingMode } = useSettings()
+
+  return (
+    <div>
+      <span>Arrow drawing mode: </span>
+      <RadioGroup
+        name='arrow-drawing-mode'
+        options={drawingModeOptions}
+        selectedValue={arrowDrawingMode}
+        onSelect={setArrowDrawingMode}
+      />
+    </div>
+  )
+}
+
+const brightnessOptions: { title: string; value: Brightness }[] = [
+  { title: 'Light', value: 'light' },
+  { title: 'Medium', value: 'medium' },
+  { title: 'Dark', value: 'dark' },
+]
+
 function AnnotationBrightness() {
-  const { annotationBrightness: brightness, setAnnotationBrightness } =
-    useSettings()
-
-  function RadioItem({ value, title }: { value: Brightness; title: string }) {
-    const id = `annotation-brightness--${value}`
-    return (
-      <>
-        <input
-          type='radio'
-          name='annotation-brightness'
-          id={id}
-          value={value}
-          checked={brightness === value}
-          onChange={(event) =>
-            setAnnotationBrightness(event.target.value as Brightness)
-          }
-        />
-        <label htmlFor={id}>{title}</label>
-      </>
-    )
-  }
-
-  const radios: [Brightness, string][] = [
-    ['light', 'Light'],
-    ['medium', 'Medium'],
-    ['dark', 'Dark'],
-  ]
+  const { annotationBrightness, setAnnotationBrightness } = useSettings()
 
   return (
     <div>
       <span>Annotation brightness: </span>
-      {radios.map(([value, title]) => (
-        <RadioItem value={value} title={title} key={value} />
-      ))}
+      <RadioGroup
+        name='annotation-brightness'
+        options={brightnessOptions}
+        selectedValue={annotationBrightness}
+        onSelect={setAnnotationBrightness}
+      />
     </div>
   )
 }
@@ -111,5 +109,61 @@ function PersistedStateDebugging() {
       <button onClick={copy}>copy persisted state</button>
       <button onClick={paste}>paste persisted state</button>
     </div>
+  )
+}
+
+function RadioGroup<Value extends string>({
+  name,
+  options,
+  selectedValue,
+  onSelect,
+}: {
+  name: string
+  options: { title: string; value: Value }[]
+  selectedValue: Value
+  onSelect: (value: Value) => void
+}) {
+  return (
+    <>
+      {options.map(({ title, value }) => (
+        <RadioItem<Value>
+          key={value}
+          name={name}
+          title={title}
+          value={value}
+          selectedValue={selectedValue}
+          onSelect={onSelect}
+        />
+      ))}
+    </>
+  )
+}
+
+function RadioItem<Value extends string>({
+  title,
+  name,
+  value,
+  selectedValue,
+  onSelect,
+}: {
+  title: string
+  name: string
+  value: Value
+  selectedValue: Value
+  onSelect: (value: Value) => void
+}) {
+  const id = `${name}--${value}`
+  return (
+    <>
+      <input
+        type='radio'
+        name={name}
+        id={id}
+        value={value}
+        checked={value === selectedValue}
+        onChange={(event) => onSelect(event.target.value as Value)}
+      />
+      <label htmlFor={id}>{title}</label>
+    </>
   )
 }

--- a/src/components/MarkerRect.tsx
+++ b/src/components/MarkerRect.tsx
@@ -13,9 +13,10 @@ type Props = {
 export default function MarkerRect({ marker, selectable }: Props) {
   const color = useCssColor(marker.color)
   const dispatch = useDispatch()
-  const { onClick, onMouseMove } = useDrawingEventHandlers()
+  const drawing = useDrawingEventHandlers()
   const onContextMenu = (event: React.MouseEvent) => {
     event.preventDefault()
+    drawing.cancelArrow()
     dispatch(selectMarker(marker))
   }
 
@@ -28,8 +29,8 @@ export default function MarkerRect({ marker, selectable }: Props) {
       fill={color}
       style={{ pointerEvents: selectable ? 'auto' : 'none' }}
       onContextMenu={onContextMenu}
-      onClick={(event) => onClick(event, marker)}
-      onMouseMove={(event) => onMouseMove(event, marker)}
+      onClick={(event) => drawing.onClick(event, marker)}
+      onMouseMove={(event) => drawing.onMouseMove(event, marker)}
     ></rect>
   )
 }

--- a/src/components/MarkerRect.tsx
+++ b/src/components/MarkerRect.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useArrowDrawingEventHandlers } from '../hooks/useArrowDrawing'
+import { useDrawingEventHandlers } from '../hooks/useArrowDrawing'
 import useCssColor from '../hooks/useCssColor'
 import { selectMarker } from '../reducer'
 import { useDispatch } from '../store'
@@ -13,7 +13,11 @@ type Props = {
 export default function MarkerRect({ marker, selectable }: Props) {
   const color = useCssColor(marker.color)
   const dispatch = useDispatch()
-  const { markerMouseEvents } = useArrowDrawingEventHandlers()
+  const { onClick, onMouseMove } = useDrawingEventHandlers()
+  const onContextMenu = (event: React.MouseEvent) => {
+    event.preventDefault()
+    dispatch(selectMarker(marker))
+  }
 
   return (
     <rect
@@ -23,10 +27,9 @@ export default function MarkerRect({ marker, selectable }: Props) {
       height={marker.height}
       fill={color}
       style={{ pointerEvents: selectable ? 'auto' : 'none' }}
-      onClick={() => dispatch(selectMarker(marker))}
-      onMouseDown={(event) => markerMouseEvents.onMouseDown(event, marker)}
-      onMouseMove={(event) => markerMouseEvents.onMouseMove(event, marker)}
-      onMouseUp={(event) => markerMouseEvents.onMouseUp(event, marker)}
+      onContextMenu={onContextMenu}
+      onClick={(event) => onClick(event, marker)}
+      onMouseMove={(event) => onMouseMove(event, marker)}
     ></rect>
   )
 }

--- a/src/components/MarkerRect.tsx
+++ b/src/components/MarkerRect.tsx
@@ -1,25 +1,19 @@
-import React, { MouseEvent } from 'react'
+import React from 'react'
+import { useArrowDrawingEventHandlers } from '../hooks/useArrowDrawing'
 import useCssColor from '../hooks/useCssColor'
+import { selectMarker } from '../reducer'
+import { useDispatch } from '../store'
 import { Marker } from '../types'
 
 type Props = {
   marker: Marker
   selectable: boolean
-  onClick: () => void
-  onMouseDown: (e: MouseEvent) => void
-  onMouseMove: (e: MouseEvent) => void
-  onMouseUp: (e: MouseEvent) => void
 }
 
-export default function MarkerRect({
-  marker,
-  selectable,
-  onClick,
-  onMouseDown,
-  onMouseMove,
-  onMouseUp,
-}: Props) {
+export default function MarkerRect({ marker, selectable }: Props) {
   const color = useCssColor(marker.color)
+  const dispatch = useDispatch()
+  const { markerMouseEvents } = useArrowDrawingEventHandlers()
 
   return (
     <rect
@@ -29,10 +23,10 @@ export default function MarkerRect({
       height={marker.height}
       fill={color}
       style={{ pointerEvents: selectable ? 'auto' : 'none' }}
-      onClick={onClick}
-      onMouseDown={onMouseDown}
-      onMouseMove={onMouseMove}
-      onMouseUp={onMouseUp}
+      onClick={() => dispatch(selectMarker(marker))}
+      onMouseDown={(event) => markerMouseEvents.onMouseDown(event, marker)}
+      onMouseMove={(event) => markerMouseEvents.onMouseMove(event, marker)}
+      onMouseUp={(event) => markerMouseEvents.onMouseUp(event, marker)}
     ></rect>
   )
 }

--- a/src/hooks/useArrowDrawing.tsx
+++ b/src/hooks/useArrowDrawing.tsx
@@ -6,7 +6,7 @@ import { useDispatch } from '../store'
 import { Arrow, Marker, Point, UnfinishedArrow } from '../types'
 import { useContainer } from './useContainer'
 import useKeyboardHandler from './useKeyboardHandler'
-import { useSettings } from './useSettings'
+import { ArrowDrawingMode, useSettings } from './useSettings'
 
 // TYPES
 
@@ -36,7 +36,7 @@ export function ArrowDrawingProvider({
   const { eventCoordinates } = useContainer()
   const [currentArrow, setCurrentArrow] =
     React.useState<UnfinishedArrow | null>(null)
-  const { showStraightArrows } = useSettings()
+  const { arrowDrawingMode } = useSettings()
   const dispatch = useDispatch()
 
   const escapeKeyHandler = React.useCallback((event: KeyboardEvent) => {
@@ -55,7 +55,7 @@ export function ArrowDrawingProvider({
       const currentPoint = eventCoordinates(event)
       if (!currentArrow) {
         if (target) {
-          setCurrentArrow(newArrow(target, showStraightArrows, currentPoint))
+          setCurrentArrow(newArrow(target, arrowDrawingMode, currentPoint))
         }
       } else if (targetIsOrigin(target, currentArrow)) {
         setCurrentArrow(null)
@@ -69,7 +69,7 @@ export function ArrowDrawingProvider({
         })
       }
     },
-    [eventCoordinates, currentArrow, showStraightArrows],
+    [eventCoordinates, currentArrow, arrowDrawingMode],
   )
 
   const onMouseMove = useCallback(
@@ -150,10 +150,9 @@ export function useCurrentArrowDrawing(): UnfinishedArrow | null {
 
 function newArrow(
   target: Arrow | Marker,
-  showStraightArrows: boolean,
+  drawingMode: ArrowDrawingMode,
   currentPoint: Point,
 ): UnfinishedArrow {
-  const drawingMode = showStraightArrows ? 'jointed' : 'freehand'
   if (isArrow(target)) {
     const fromPoint = pointOnPolylineNearPoint(currentPoint, [
       target.fromPoint,

--- a/src/hooks/useArrowDrawing.tsx
+++ b/src/hooks/useArrowDrawing.tsx
@@ -13,6 +13,7 @@ import { useSettings } from './useSettings'
 type EventHandlers = {
   onClick: (event: React.MouseEvent, target: Marker | Arrow | null) => void
   onMouseMove: (event: React.MouseEvent, target: Marker | null) => void
+  cancelArrow: () => void
 }
 
 // CONTEXTS
@@ -99,12 +100,17 @@ export function ArrowDrawingProvider({
     [currentArrow, eventCoordinates],
   )
 
+  const cancelArrow = React.useCallback(() => {
+    setCurrentArrow(null)
+  }, [])
+
   const handlers: EventHandlers = React.useMemo(
     () => ({
       onClick,
       onMouseMove,
+      cancelArrow,
     }),
-    [onClick, onMouseMove],
+    [onClick, onMouseMove, cancelArrow],
   )
 
   return (

--- a/src/hooks/useSettings.tsx
+++ b/src/hooks/useSettings.tsx
@@ -7,28 +7,31 @@ import React, {
 } from 'react'
 import { Brightness } from '../colors'
 
+export type ArrowDrawingMode = 'jointed' | 'freehand'
+
 export type Settings = {
-  showStraightArrows: boolean
+  arrowDrawingMode: ArrowDrawingMode
   annotationBrightness: Brightness
-  setShowStraightArrows: (newValue: boolean) => void
+  setArrowDrawingMode: (drawingMode: ArrowDrawingMode) => void
   setAnnotationBrightness: (newValue: Brightness) => void
 }
 
 const SettingsContext = createContext<Settings | null>(null)
 
 export function SettingsProvider({ children }: PropsWithChildren<{}>) {
-  const [showStraightArrows, setShowStraightArrows] = useState(false)
+  const [arrowDrawingMode, setArrowDrawingMode] =
+    useState<ArrowDrawingMode>('freehand')
   const [annotationBrightness, setAnnotationBrightness] =
     useState<Brightness>('medium')
 
   const value = useMemo(
     () => ({
-      showStraightArrows,
+      arrowDrawingMode,
       annotationBrightness,
-      setShowStraightArrows,
+      setArrowDrawingMode,
       setAnnotationBrightness,
     }),
-    [showStraightArrows, annotationBrightness],
+    [arrowDrawingMode, annotationBrightness],
   )
 
   return (

--- a/src/index.scss
+++ b/src/index.scss
@@ -92,6 +92,26 @@ body {
       height: 100%;
       mix-blend-mode: multiply;
     }
+
+    .drawing-cancelation-button {
+      pointer-events: auto;
+      position: sticky;
+      bottom: 1rem;
+      left: 1rem;
+      font-size: 1rem;
+      max-width: 10rem;
+      text-align: left;
+      outline: 0;
+      padding: 0.5rem;
+      margin: 0;
+      border: 1px solid black;
+      border-radius: 0.25rem;
+      background: #fff;
+
+      &:hover {
+        background: #eee;
+      }
+    }
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import { Color } from './colors'
+import { ArrowDrawingMode } from './hooks/useSettings'
 
 export type Point = { x: number; y: number }
 
@@ -26,7 +27,7 @@ export type Marker = TextSelection & {
 }
 
 export type UnfinishedArrow = {
-  drawingMode: 'jointed' | 'freehand'
+  drawingMode: ArrowDrawingMode
   fromPoint: Point
   fromMarker: string
   fromArrow: string | null

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,8 +26,10 @@ export type Marker = TextSelection & {
 }
 
 export type UnfinishedArrow = {
+  drawingMode: 'jointed' | 'freehand'
   fromPoint: Point
   fromMarker: string
+  fromArrow: string | null
   midPoints: Point[]
   toPoint: Point
   toMarker: string | null


### PR DESCRIPTION
In order to make arrow drawing easier and more capable we decided to change the mouse interactions for markers and arrows.

# Rationale

Up until now you had to click on a marker/arrow to open its popover, where you could change its color or delete it. If you started dragging from the marker/arrow, you would start a new arrow that was completed once you let go of the mouse over a different marker.

There are several problems with this drag interaction:
1. It's hard to operate using a trackpad
2. It's pretty much impossible to draw arrows that span multiple viewports, because you can't scroll mid-drag
3. It made it very hard to add jointed arrows (#4) in a way that was consistent with freehand arrow drawing.

# Changes

We've decided to change the way this works:

* First of all, **arrow/marker popovers now open on _right_ mouse click** and replace the default context menu. The rationale for this is that this operation is less common and it felt like a reasonable place to "hide" these operations in (delete + change color), since they're probably relatively uncommon.
* **Arrow drawing is triggered on click, instead of on drag**
* An arrow is added once the destination marker is clicked
* You can hit the escape key or click on a fixed-position button to cancel the current arrow drawing
* The "Use straight arrows" checkbox has been replaced with a "drawing mode" radio select to choose between freehand arrows and jointed arrows
* When the "jointed" option is selected, clicking outside of a marker while drawing adds a joint to the arrow.

We felt that this "click to add an arrow" interaction solves the three issues:

1. It's easier to operate because you don't need to keep the mouse button down
2. Arrows can span multiple viewports because you can now scroll while drawing
3. Jointed arrows make sense: instead of clicking a destination marker, just click on the background to add a joint

# Implementation

Changing the popover to trigger on right mouse click instead of left mouse click is done by using `onContextMenu` instead of `onClick` on markers and arrows.

The `useArrowDrawing` hook now uses a react context so that the event handlers it returns can be used in `MarkerRect` and in `ArrowLine` without needing to pass them down through the component tree. The tree isn't very deep but I think it makes for cleaner code.

The event handlers it returns are simplified: instead of a weird combination of onMouseDown, onMouseMove and onMouseUp for markers/arrows/svg, now it's just onClick and onMouseMove that are pretty much consistent across the three consumers (marker/arrow/svg). Plus an extra `cancelDrawing` that's triggered on right mouse click (onContextMenu) for markers and arrows, as well as the `onClick` of the `DrawingCancelationButton`.


# Concerns

1. It can get janky (as in: lose frames) when a lot of arrows have been added
2. The drawing cancelation button can be a bit distracting and/or it doesn't look like a button

The first concern will be handled in an upcoming PR that includes a bunch of performance tweaks. The second one depends on how people react to it and whether they even see it as a problem.