### PR TITLE
Change the copy on the home page and add permalink instructions

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -165,10 +165,44 @@ body {
   grid-template-rows: repeat(4, auto);
 }
 
-.file-form {
-  input {
-    width: 40rem;
+.home-page {
+  main {
+    width: 50rem;
     max-width: 95%;
+    margin: 0 auto;
+
+    .file-form {
+      &__input-row {
+        display: flex;
+        flex-direction: row;
+
+        input {
+          flex-grow: 1;
+          flex-shrink: 1;
+        }
+      }
+
+      [role='alert'] {
+        border: 0.125rem solid red;
+        background: rgb(255, 245, 245);
+        padding: 1rem;
+        margin-top: 2rem;
+
+        .permalink-diagram {
+          margin-top: 3rem;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+        }
+      }
+    }
+
+    .trimmable-url {
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      max-width: 100%;
+      overflow: hidden;
+    }
   }
 }
 

--- a/src/source.ts
+++ b/src/source.ts
@@ -12,12 +12,12 @@ export function parseHash(hash: string): Source | null {
     return null
   }
 
-  const file = parsePath(githubPath)
-  if (!file) {
+  const parseResult = parsePath(githubPath)
+  if (parseResult.type !== 'success') {
     return null
   }
 
-  return { type: 'githubPermalink', file }
+  return { type: 'githubPermalink', file: parseResult.file }
 }
 
 export function sourceHash(source: Source): string {


### PR DESCRIPTION
People don't read text so hopefully showing the same information twice will help.

I've made the github url parsing code more explicit (it parses the url in stages now, instead of using an unclear regex pattern).

Now the parsing can have three possible results:

1. Fail because the url isn't a github url
2. Fail because the url is a github url but not a permalink
3. Succeed with the details extracted from the permalink

This allows us to show a more specific error message in the second case.

<img width="1028" alt="Screen Shot 2022-02-25 at 17 19 23" src="https://user-images.githubusercontent.com/777023/155741631-0e491341-8a4e-44ef-b8c2-993111a4322d.png">